### PR TITLE
fix: allow line breaks in backtick identifiers

### DIFF
--- a/src/feel.grammar
+++ b/src/feel.grammar
@@ -467,7 +467,7 @@ commaSep<Expr> {
   }
 
   backtickIdentifier[@dialect=camunda] {
-    "`" (![\\\n`] | "\\" _)* "`"
+    "`" (![`] | "\\" _)* "`"
   }
 
   @precedence { BlockComment, LineComment, divide }

--- a/test/camunda.txt
+++ b/test/camunda.txt
@@ -3,13 +3,18 @@
 `foo`;
 foo.`bar`;
 foo.`bar-baz`;
+`foo
+baz`;
+`foo\``
 
 ==>
 
 Expressions(
   VariableName(BacktickIdentifier(...)),
   PathExpression(VariableName(...), VariableName(BacktickIdentifier(...))),
-  PathExpression(VariableName(...), VariableName(BacktickIdentifier(...)))
+  PathExpression(VariableName(...), VariableName(BacktickIdentifier(...))),
+  VariableName(BacktickIdentifier(...)),
+  VariableName(BacktickIdentifier(...))
 )
 
 


### PR DESCRIPTION
### Proposed Changes

Integrate changes from upstream https://github.com/nikku/lezer-feel/pull/57
<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
